### PR TITLE
Fix lib path and build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To build it:
 ```
 cd minimal_app/
 rm CMakeCache.txt CMakeFiles/ cmake_install.cmake -fr
-cmake -D USER=`whoami` .
+cmake .
 make
 ```
 Sample execution:
@@ -104,7 +104,7 @@ Sample execution:
 ```
 MayamaTakeshi@takeshi-desktop:unimrcp_experiments$ cd minimal_app/
 MayamaTakeshi@takeshi-desktop:minimal_app$ rm CMakeCache.txt CMakeFiles/ cmake_install.cmake -fr
-MayamaTakeshi@takeshi-desktop:minimal_app$ cmake -D USER=`whoami` .
+MayamaTakeshi@takeshi-desktop:minimal_app$ cmake .
 -- The C compiler identification is GNU 10.2.1
 -- The CXX compiler identification is GNU 10.2.1
 -- Detecting C compiler ABI info

--- a/minimal_app/CMakeLists.txt
+++ b/minimal_app/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(app PUBLIC
 # strangely, "~/src" fails in targeet_link_library so we must pass the USER
 
 target_link_libraries(app PUBLIC
-   "/home/${USER}/src/git/unimrcp/libs/apr-toolkit/.libs/libaprtoolkit.a"
+   "/usr/local/src/git/unimrcp/libs/apr-toolkit/.libs/libaprtoolkit.a"
    "/usr/local/apr/lib/libaprutil-1.so"
    "/usr/local/apr/lib/libapr-1.so"
    )


### PR DESCRIPTION
## Change

- Fixed path to `libaprtoolkit.a`
- Removed cmake args unused any more
- Fixed the explanation in README how to build